### PR TITLE
Constrain require_path to only lib

### DIFF
--- a/wkhtmltoimage-binary.gemspec
+++ b/wkhtmltoimage-binary.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.require_paths = ["."]
+  gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
I have some cucumber features that (amongst other things) test some rake jobs, to do so they do `load 'Rakefile'`;
this worked up to including your gem, upon which the gem's Rakefile began to load instead of my app's

While realistically, I should maybe not do this, it's probably also best to avoid causing such problems.

Cheers :beers: 

