### PR TITLE
Add binary for Debian 8 (jessie)

### DIFF
--- a/bin/wkhtmltoimage
+++ b/bin/wkhtmltoimage
@@ -2,11 +2,16 @@
 
 arch = case RUBY_PLATFORM
   when /64.*linux/
-    'amd64'
+    case `lsb_release -c`
+    when /jessie/  # Debian 8 - Jessie
+      'jessie-amd64'
+    else
+      'amd64'
+    end
   when /linux/
     'i386'
   when /darwin/
-    'darwin-x86'  
+    'darwin-x86'
   else
     raise "Invalid platform. Must be running linux or Mac."
 end


### PR DESCRIPTION
The packaged linux binary does not work in Debian 8 (wrong libjpeg version, as somebody complained).
I've added the binary from the official wkhtmltopdf package built for Debian 8.
