### PR TITLE
Centos 6.7 (6.6) binary

### DIFF
--- a/bin/wkhtmltoimage
+++ b/bin/wkhtmltoimage
@@ -1,13 +1,26 @@
 #!/usr/bin/env ruby
 
+require 'mkmf'
+
 arch = case RUBY_PLATFORM
   when /64.*linux/
-    case `lsb_release -c`
-    when /jessie/  # Debian 8 - Jessie
-      'jessie-amd64'
+    lsb_release_exe = find_executable('lsb_release')
+    if lsb_release_exe
+      case `lsb_release -c`
+      when /jessie/  # Debian 8 - Jessie
+        'jessie-amd64'
+      else
+        # alternative binary for CentOS 6.7
+        release = `cat /etc/*release`
+        if release.match(/CentOS release 6\.7/)
+          'centos67-amd64'
+        else
+          'amd64'
+        end
+      end 
     else
-      'amd64'
-    end
+      raise '`lsb_release` command not found on host OS. Please install.' 
+    end 
   when /linux/
     'i386'
   when /darwin/

--- a/lib/wkhtmltoimage-binary/version.rb
+++ b/lib/wkhtmltoimage-binary/version.rb
@@ -1,5 +1,5 @@
 module Wkhtmltoimage
   module Binary
-    VERSION = "0.12.2"
+    VERSION = "0.12.3"
   end
 end


### PR DESCRIPTION
Hi, this may or may not be useful. I was having trouble with your existing binaries amd64 with CentOS 6.7. I was getting the following error:

libjpeg.so.8: cannot open shared object file

I finally just pulled the rpm package from http://wkhtmltopdf.org/downloads.html for CentOS 6.6, pulled it apart and substituted the binary and found it working. 

So in my changes here I check for Centos 6.7 (I realize this could be perhaps applied to any Centos 6.*), and use the alternative binary if thats the case.

Also was hitting error with the lsb_version check so added a thrown error if that command fails so at least it would be easier for someone to fix the issue (ie adding the package containing that command).

As before, not sure if this helps at all but thought I would send it to you :)
