### PR TITLE
support m1

### DIFF
--- a/bin/wkhtmltoimage
+++ b/bin/wkhtmltoimage
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'rbconfig'
+
 arch = case RUBY_PLATFORM
        when /64.*linux/
          'amd64'
@@ -12,6 +14,9 @@ arch = case RUBY_PLATFORM
        else
          raise "Invalid platform. Must be running linux or Mac."
        end
+
+host_cpu = RbConfig::CONFIG['host_cpu']
+arch = 'darwin-x64' if host_cpu == 'arm'
 
 args = $*.map { |x| x.include?(' ') ? "'" + x + "'" : x }
 cmd = File.expand_path "#{File.dirname(__FILE__)}/../libexec/wkhtmltoimage-#{arch}"

--- a/bin/wkhtmltoimage
+++ b/bin/wkhtmltoimage
@@ -16,7 +16,7 @@ arch = case RUBY_PLATFORM
        end
 
 host_cpu = RbConfig::CONFIG['host_cpu']
-arch = 'darwin-x64' if host_cpu == 'arm'
+arch = 'darwin-x64' if host_cpu == 'arm' && arch == 'darwin-x86'
 
 args = $*.map { |x| x.include?(' ') ? "'" + x + "'" : x }
 cmd = File.expand_path "#{File.dirname(__FILE__)}/../libexec/wkhtmltoimage-#{arch}"


### PR DESCRIPTION
```
[7] pry(main)> require "rbconfig"
=> false
[8] pry(main)> RbConfig::CONFIG
=> {"DESTDIR"=>"",
 "MAJOR"=>"2",
 "MINOR"=>"3",
 "TEENY"=>"0",
 "PATCHLEVEL"=>"384",
 "INSTALL"=>"/usr/bin/install -c",
 "EXEEXT"=>"",
 "prefix"=>"/Users/paulomcnally/.rbenv/versions/2.3.6",
 "ruby_install_name"=>"ruby",
 "RUBY_INSTALL_NAME"=>"ruby",
 "RUBY_SO_NAME"=>"ruby",
 "exec"=>"exec",
 "ruby_pc"=>"ruby-2.3.pc",
 "PACKAGE"=>"ruby",
 "BUILTIN_TRANSSRCS"=>" enc/trans/newline.c",
 "USE_RUBYGEMS"=>"YES",
 "MANTYPE"=>"doc",
 "NROFF"=>"/usr/bin/nroff",
 "vendorarchhdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0/vendor_ruby/-darwin21",
 "sitearchhdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0/site_ruby/-darwin21",
 "rubyarchhdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0/-darwin21",
 "vendorhdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0/vendor_ruby",
 "sitehdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0/site_ruby",
 "rubyhdrdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/include/ruby-2.3.0",
 "RUBY_SEARCH_PATH"=>"",
 "UNIVERSAL_INTS"=>"",
 "UNIVERSAL_ARCHNAMES"=>"",
 "configure_args"=>
  " '--prefix=/Users/paulomcnally/.rbenv/versions/2.3.6' '--with-readline-dir=/opt/homebrew/opt/readline' '--with-openssl-dir=/opt/homebrew/opt/openssl@1.0' 'CC=clang' 'CFLAGS= -DUSE_FFI_CLOSURE_ALLOC' 'LDFLAGS=-L/Users/paulomcnally/.rbenv/versions/2.3.6/lib -L/opt/homebrew/opt/openssl@1.0/lib' 'CPPFLAGS=-I/Users/paulomcnally/.rbenv/versions/2.3.6/include -I/opt/homebrew/opt/openssl@1.0/include'",
 "CONFIGURE"=>"configure",
 "vendorarchdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/vendor_ruby/2.3.0/-darwin21",
 "vendorlibdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/vendor_ruby/2.3.0",
 "vendordir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/vendor_ruby",
 "sitearchdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/site_ruby/2.3.0/-darwin21",
 "sitelibdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/site_ruby/2.3.0",
 "sitedir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/site_ruby",
 "rubyarchdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/2.3.0/-darwin21",
 "rubylibdir"=>"/Users/paulomcnally/.rbenv/versions/2.3.6/lib/ruby/2.3.0"
```

```bash
▶ bin/wkhtmltoimage https://google.com out.jpg
arm
bin/wkhtmltoimage:25:in `exec': Bad CPU type in executable - /Users/paulomcnally/github/paulomcnally/wkhtmltoimage-binary-fork/libexec/wkhtmltoimage-darwin-x86 (Errno::E086)
	from bin/wkhtmltoimage:25:in `<main>'
```