### PR TITLE
Support ARM64 platform.

### DIFF
--- a/bin/wkhtmltoimage
+++ b/bin/wkhtmltoimage
@@ -1,10 +1,14 @@
 #!/usr/bin/env ruby
 
 arch = case RUBY_PLATFORM
+       when /aarch64.*linux/
+         'aarch64'
        when /64.*linux/
          'amd64'
        when /linux/
          'i386'
+       when /arm64.*darwin/
+         'darwin-x64'
        when /64.*darwin/
          'darwin-x64'
        when /darwin/


### PR DESCRIPTION
- Modify platform detection logic in wkhtmltoimage to add ARM64 support (aarch64-linux → 'aarch64', arm64-darwin → fallback to 'darwin-x64' for Rosetta)

- Add 43MB ARM64 binary wkhtmltoimage-aarch64 to libexec/ directory (extracted from official wkhtmltopdf 0.12.6.1 release)